### PR TITLE
Allow functions to run outside a VPC

### DIFF
--- a/secret-rotation-function/README.md
+++ b/secret-rotation-function/README.md
@@ -76,9 +76,9 @@ module "auth_token_rotation" {
 | <a name="input_rotation_days"></a> [rotation\_days](#input\_rotation\_days) | Number of days after which the secret is rotated | `number` | `30` | no |
 | <a name="input_runtime"></a> [runtime](#input\_runtime) | Runtime of the rotation function | `string` | n/a | yes |
 | <a name="input_secret_arn"></a> [secret\_arn](#input\_secret\_arn) | ARN of the secret to rotate | `string` | n/a | yes |
-| <a name="input_security_group_ids"></a> [security\_group\_ids](#input\_security\_group\_ids) | Security groups which the rotation function should use | `list(string)` | n/a | yes |
+| <a name="input_security_group_ids"></a> [security\_group\_ids](#input\_security\_group\_ids) | Security groups which the rotation function should use | `list(string)` | `[]` | no |
 | <a name="input_source_file"></a> [source\_file](#input\_source\_file) | File containing the rotatation handler | `string` | n/a | yes |
-| <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | Subnets in which this function should run | `list(string)` | n/a | yes |
+| <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | Subnets in which this function should run | `list(string)` | `[]` | no |
 | <a name="input_variables"></a> [variables](#input\_variables) | Environment variables for the rotation function | `map(string)` | `{}` | no |
 
 ## Outputs

--- a/secret-rotation-function/main.tf
+++ b/secret-rotation-function/main.tf
@@ -25,9 +25,13 @@ resource "aws_lambda_function" "rotation" {
     )
   }
 
-  vpc_config {
-    security_group_ids = var.security_group_ids
-    subnet_ids         = var.subnet_ids
+  dynamic "vpc_config" {
+    for_each = length(concat(var.security_group_ids, var.subnet_ids)) == 0 ? [] : [true]
+
+    content {
+      security_group_ids = var.security_group_ids
+      subnet_ids         = var.subnet_ids
+    }
   }
 
   depends_on = [

--- a/secret-rotation-function/variables.tf
+++ b/secret-rotation-function/variables.tf
@@ -39,6 +39,7 @@ variable "secret_arn" {
 variable "security_group_ids" {
   description = "Security groups which the rotation function should use"
   type        = list(string)
+  default     = []
 }
 
 variable "source_file" {
@@ -49,4 +50,5 @@ variable "source_file" {
 variable "subnet_ids" {
   description = "Subnets in which this function should run"
   type        = list(string)
+  default     = []
 }


### PR DESCRIPTION
For functions which don't require access to VPC resources, there is no reason to run them within a VPC.
