### PR TITLE
Allow using existing IAM role for rotation

### DIFF
--- a/secret-rotation-function/README.md
+++ b/secret-rotation-function/README.md
@@ -54,10 +54,6 @@ module "auth_token_rotation" {
 | <a name="provider_archive"></a> [archive](#provider\_archive) | ~> 2.2 |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.45 |
 
-## Modules
-
-No modules.
-
 ## Resources
 
 | Name | Type |

--- a/secret-rotation-function/makefile
+++ b/secret-rotation-function/makefile
@@ -1,4 +1,5 @@
 TFLINTRC    := ../.tflint.hcl
+TFDOCSRC    ?= ../.terraform-docs.yml
 MODULEFILES := $(wildcard *.tf)
 
 .PHONY: default
@@ -30,7 +31,7 @@ lint: .lint
 	@touch .lintinit
 
 README.md: $(MODULEFILES)
-	terraform-docs markdown table . --output-file README.md
+	terraform-docs --config "$(TFDOCSRC)" markdown table . --output-file README.md
 
 .fmt: $(MODULEFILES)
 	terraform fmt -check

--- a/secret/README.md
+++ b/secret/README.md
@@ -80,6 +80,7 @@ using the [secret rotation function module].
 | [aws_iam_policy_document.rotation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.rotation_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.secret](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_role.rotation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_role) | data source |
 | [aws_region.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs
@@ -87,11 +88,13 @@ using the [secret rotation function module].
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_admin_principals"></a> [admin\_principals](#input\_admin\_principals) | Principals allowed to peform admin actions (default: current account) | `list(string)` | `null` | no |
+| <a name="input_create_rotation_role"></a> [create\_rotation\_role](#input\_create\_rotation\_role) | Set to false to use an existing IAM role for rotation | `bool` | `true` | no |
 | <a name="input_description"></a> [description](#input\_description) | Description for this secret | `string` | `null` | no |
 | <a name="input_initial_value"></a> [initial\_value](#input\_initial\_value) | Initial value for this secret | `string` | n/a | yes |
 | <a name="input_name"></a> [name](#input\_name) | Name for this secret | `string` | n/a | yes |
 | <a name="input_read_principals"></a> [read\_principals](#input\_read\_principals) | Principals allowed to read the secret (default: current account) | `list(string)` | `null` | no |
 | <a name="input_resource_tags"></a> [resource\_tags](#input\_resource\_tags) | Tags to be applied to created resources | `map(string)` | `{}` | no |
+| <a name="input_rotation_role_name"></a> [rotation\_role\_name](#input\_rotation\_role\_name) | Override the name for the rotation role | `string` | `null` | no |
 | <a name="input_rotation_trust_policy"></a> [rotation\_trust\_policy](#input\_rotation\_trust\_policy) | Overrides for the rotation role trust policy | `string` | `null` | no |
 | <a name="input_secret_policy"></a> [secret\_policy](#input\_secret\_policy) | Overrides for the secret resource policy | `string` | `null` | no |
 | <a name="input_trust_tags"></a> [trust\_tags](#input\_trust\_tags) | Tags required on principals accessing the secret | `map(string)` | `{}` | no |

--- a/secret/makefile
+++ b/secret/makefile
@@ -1,4 +1,5 @@
 TFLINTRC    := ../.tflint.hcl
+TFDOCSRC    ?= ../.terraform-docs.yml
 MODULEFILES := $(wildcard *.tf)
 
 .PHONY: default
@@ -30,7 +31,7 @@ lint: .lint
 	@touch .lintinit
 
 README.md: $(MODULEFILES)
-	terraform-docs markdown table . --output-file README.md
+	terraform-docs --config "$(TFDOCSRC)" markdown table . --output-file README.md
 
 .fmt: $(MODULEFILES)
 	terraform fmt -check

--- a/secret/outputs.tf
+++ b/secret/outputs.tf
@@ -25,12 +25,12 @@ output "policy_json" {
 
 output "rotation_role_arn" {
   description = "ARN of the IAM role allowed to rotate this secret"
-  value       = aws_iam_role.rotation.arn
+  value       = data.aws_iam_role.rotation.arn
 }
 
 output "rotation_role_name" {
   description = "Name of the IAM role allowed to rotate this secret"
-  value       = aws_iam_role.rotation.name
+  value       = data.aws_iam_role.rotation.name
 }
 
 output "id" {

--- a/secret/variables.tf
+++ b/secret/variables.tf
@@ -4,6 +4,12 @@ variable "admin_principals" {
   default     = null
 }
 
+variable "create_rotation_role" {
+  description = "Set to false to use an existing IAM role for rotation"
+  type        = bool
+  default     = true
+}
+
 variable "initial_value" {
   description = "Initial value for this secret"
   type        = string
@@ -30,6 +36,12 @@ variable "resource_tags" {
   description = "Tags to be applied to created resources"
   type        = map(string)
   default     = {}
+}
+
+variable "rotation_role_name" {
+  description = "Override the name for the rotation role"
+  type        = string
+  default     = null
 }
 
 variable "rotation_trust_policy" {


### PR DESCRIPTION
When managing rotation functions for a set of secrets related to the same
resources, it makes sense to re-use the same rotation role ARN as it will need
to access all secrets related to the underlying resource.

An example where this is useful is for a rotation function that manages both the
single-user, owner role for Postgres and the alternative-user, non-owner role.
