### PR TITLE
Add module for creating a read policy

### DIFF
--- a/.github/workflows/read-secret-policy.yaml
+++ b/.github/workflows/read-secret-policy.yaml
@@ -1,0 +1,9 @@
+name: "Module: read-secret-policy"
+on:
+- push
+
+jobs:
+  terraform:
+    uses: ./.github/workflows/terraform.yaml
+    with:
+      module: read-secret-policy

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ using AWS Secrets Manager.
 
 * [secret](./secret/README.md)
 * [secret-rotation-function](./secret-rotation-function/README.md)
+* [read-secret-policy](./read-secret-policy/README.md)
 
 ## Development
 

--- a/read-secret-policy/README.md
+++ b/read-secret-policy/README.md
@@ -1,0 +1,67 @@
+# Secret Read Policy
+
+This module creates an IAM policy which allows the principal to read a given
+list of secrets from [AWS Secrets Manager]. It also allows decryption using the
+KMS key attached to each secret.
+
+Example:
+
+``` hcl
+module "secret_read_policy" {
+  source = "github.com/thoughtbot/terraform-aws-secrets//secret-read-policy"
+
+  policy_name = "example-read-secrets"
+
+  # If provided, the IAM policy will attached to the given roles
+  role_names = ["example-service"]
+
+  secrets_manager_secrets = [
+    "rds-postgres-example"
+    "ses-smtp"
+    "rds-postgres-replica"
+  ]
+}
+```
+
+[AWS Secrets Manager]: https://docs.aws.amazon.com/secretsmanager/latest/userguide/intro.html
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.15.5 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_iam_policy.read_secrets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role_policy_attachment.read_secrets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_policy_document.read_secrets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_kms_key.secrets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_key) | data source |
+| [aws_secretsmanager_secret.secrets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_policy_name"></a> [policy\_name](#input\_policy\_name) | Name of the IAM policy allowed to read secrets | `string` | n/a | yes |
+| <a name="input_role_names"></a> [role\_names](#input\_role\_names) | If provided, an IAM policy will be attached to the given roles | `list(string)` | `[]` | no |
+| <a name="input_secret_names"></a> [secret\_names](#input\_secret\_names) | Names of SecretsManager secrets the role can read | `list(string)` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_policy_arn"></a> [policy\_arn](#output\_policy\_arn) | ARN of the IAM policy created to grant secrets |
+| <a name="output_policy_attachments"></a> [policy\_attachments](#output\_policy\_attachments) | Role attachments for the created IAM policy |
+| <a name="output_policy_json"></a> [policy\_json](#output\_policy\_json) | IAM policy granting read access to these secrets |
+<!-- END_TF_DOCS -->

--- a/read-secret-policy/main.tf
+++ b/read-secret-policy/main.tf
@@ -1,0 +1,42 @@
+resource "aws_iam_policy" "read_secrets" {
+  name   = var.policy_name
+  policy = data.aws_iam_policy_document.read_secrets.json
+}
+
+resource "aws_iam_role_policy_attachment" "read_secrets" {
+  for_each = toset(var.role_names)
+
+  policy_arn = aws_iam_policy.read_secrets.arn
+  role       = each.value
+}
+
+data "aws_secretsmanager_secret" "secrets" {
+  for_each = toset(var.secret_names)
+
+  name = each.value
+}
+
+data "aws_kms_key" "secrets" {
+  for_each = data.aws_secretsmanager_secret.secrets
+
+  key_id = each.value.kms_key_id
+}
+
+data "aws_iam_policy_document" "read_secrets" {
+  statement {
+    sid = "ReadSecrets"
+    actions = [
+      "secretsmanager:DescribeSecret",
+      "secretsmanager:GetSecretValue"
+    ]
+    resources = values(data.aws_secretsmanager_secret.secrets)[*].arn
+  }
+
+  statement {
+    sid = "DecryptSecrets"
+    actions = [
+      "kms:Decrypt"
+    ]
+    resources = values(data.aws_kms_key.secrets)[*].arn
+  }
+}

--- a/read-secret-policy/makefile
+++ b/read-secret-policy/makefile
@@ -1,0 +1,59 @@
+TFLINTRC    := ../.tflint.hcl
+TFDOCSRC    ?= ../.terraform-docs.yml
+MODULEFILES := $(wildcard *.tf)
+
+.PHONY: default
+default: checkfmt validate docs lint
+
+.PHONY: checkfmt
+checkfmt: .fmt
+
+.PHONY: fmt
+fmt: $(MODULEFILES)
+	terraform fmt
+	@touch .fmt
+
+.PHONY: validate
+validate: .validate
+
+.PHONY: docs
+docs: README.md
+
+.PHONY: lint
+lint: .lint
+
+.lint: $(MODULEFILES) .lintinit
+	tflint --config=$(TFLINTRC)
+	@touch .lint
+
+.lintinit: $(TFLINTRC)
+	tflint --init --config=$(TFLINTRC)
+	@touch .lintinit
+
+README.md: $(MODULEFILES)
+	terraform-docs --config "$(TFDOCSRC)" markdown table . --output-file README.md
+
+.fmt: $(MODULEFILES)
+	terraform fmt -check
+	@touch .fmt
+
+.PHONY: init
+init: .init
+
+.init: versions.tf
+	terraform init -backend=false
+	@touch .init
+
+.validate: .init $(MODULEFILES) $(wildcard *.tf.example)
+	echo | cat - $(wildcard *.tf.example) > test.tf
+	if AWS_DEFAULT_REGION=us-east-1 terraform validate; then \
+		rm test.tf; \
+		touch .validate; \
+	else \
+		rm test.tf; \
+		false; \
+	fi
+
+.PHONY: clean
+clean:
+	rm -rf .fmt .init .lint .lintinit .terraform .terraform.lock.hcl .validate

--- a/read-secret-policy/outputs.tf
+++ b/read-secret-policy/outputs.tf
@@ -1,0 +1,14 @@
+output "policy_json" {
+  description = "IAM policy granting read access to these secrets"
+  value       = data.aws_iam_policy_document.read_secrets.json
+}
+
+output "policy_arn" {
+  description = "ARN of the IAM policy created to grant secrets"
+  value       = aws_iam_policy.read_secrets.arn
+}
+
+output "policy_attachments" {
+  description = "Role attachments for the created IAM policy"
+  value       = values(aws_iam_role_policy_attachment.read_secrets)[*].id
+}

--- a/read-secret-policy/variables.tf
+++ b/read-secret-policy/variables.tf
@@ -1,0 +1,15 @@
+variable "policy_name" {
+  description = "Name of the IAM policy allowed to read secrets"
+  type        = string
+}
+
+variable "role_names" {
+  description = "If provided, an IAM policy will be attached to the given roles"
+  type        = list(string)
+  default     = []
+}
+
+variable "secret_names" {
+  description = "Names of SecretsManager secrets the role can read"
+  type        = list(string)
+}

--- a/read-secret-policy/versions.tf
+++ b/read-secret-policy/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 0.15.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+}


### PR DESCRIPTION
We generate policy JSON to read each secret individually, which requires creating a policy and merging the combined JSON into it. This creates some additional work and also sometimes creates IAM policy statements which are too large for a single policy.

This creates a module which will create a standalone policy for reading a list of secrets, generating a much smaller policy which would not exceed the quota until an extreme number of secrets is needed. It can also attach it to roles by name.
