### PR TITLE
Add module for user-managed secrets

### DIFF
--- a/.github/workflows/user-managed-secret.yaml
+++ b/.github/workflows/user-managed-secret.yaml
@@ -1,0 +1,9 @@
+name: "Module: user-managed-secret"
+on:
+- push
+
+jobs:
+  terraform:
+    uses: ./.github/workflows/terraform.yaml
+    with:
+      module: user-managed-secret

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ using AWS Secrets Manager.
 * [secret](./secret/README.md)
 * [secret-rotation-function](./secret-rotation-function/README.md)
 * [read-secret-policy](./read-secret-policy/README.md)
+* [user-managed-secret](./user-managed-secret/README.md)
 
 ## Development
 

--- a/secret/README.md
+++ b/secret/README.md
@@ -88,6 +88,7 @@ using the [secret rotation function module].
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_admin_principals"></a> [admin\_principals](#input\_admin\_principals) | Principals allowed to peform admin actions (default: current account) | `list(string)` | `null` | no |
+| <a name="input_create_rotation_policy"></a> [create\_rotation\_policy](#input\_create\_rotation\_policy) | Set to false to disable creation of an IAM policy for rotation | `bool` | `true` | no |
 | <a name="input_create_rotation_role"></a> [create\_rotation\_role](#input\_create\_rotation\_role) | Set to false to use an existing IAM role for rotation | `bool` | `true` | no |
 | <a name="input_description"></a> [description](#input\_description) | Description for this secret | `string` | `null` | no |
 | <a name="input_initial_value"></a> [initial\_value](#input\_initial\_value) | Initial value for this secret | `string` | n/a | yes |
@@ -105,6 +106,7 @@ using the [secret rotation function module].
 | Name | Description |
 |------|-------------|
 | <a name="output_arn"></a> [arn](#output\_arn) | ARN of the created secret |
+| <a name="output_environment_variables"></a> [environment\_variables](#output\_environment\_variables) | Environment variables provided by this secret |
 | <a name="output_id"></a> [id](#output\_id) | Id of the created secret |
 | <a name="output_kms_key_alias"></a> [kms\_key\_alias](#output\_kms\_key\_alias) | Alias of the KMS key encrypting the secret |
 | <a name="output_kms_key_arn"></a> [kms\_key\_arn](#output\_kms\_key\_arn) | Alias of the KMS key encrypting the secret |

--- a/secret/outputs.tf
+++ b/secret/outputs.tf
@@ -3,6 +3,11 @@ output "arn" {
   value       = aws_secretsmanager_secret.this.arn
 }
 
+output "environment_variables" {
+  description = "Environment variables provided by this secret"
+  value       = local.env_vars
+}
+
 output "id" {
   description = "Id of the created secret"
   value       = aws_secretsmanager_secret.this.id
@@ -30,12 +35,12 @@ output "policy_json" {
 
 output "rotation_role_arn" {
   description = "ARN of the IAM role allowed to rotate this secret"
-  value       = data.aws_iam_role.rotation.arn
+  value       = join("", data.aws_iam_role.rotation[*].arn)
 }
 
 output "rotation_role_name" {
   description = "Name of the IAM role allowed to rotate this secret"
-  value       = data.aws_iam_role.rotation.name
+  value       = join("", data.aws_iam_role.rotation[*].name)
 }
 
 output "secret_name" {

--- a/user-managed-secret/README.md
+++ b/user-managed-secret/README.md
@@ -1,0 +1,65 @@
+# User Managed Secret
+
+Creates an [AWS Secrets Manager] which is expected to be manually updated by a
+developer. A list of environment variable names can be provided, which must then
+be filled in using the SecretsManager UI or CLI. Rotation is disabled for the
+secret.
+
+Example:
+
+``` terraform
+module "smtp" {
+  source = "github.com/thoughtbot/terraform-aws-secrets//secret"
+
+  environment_variables = ["USERNAME", "PASSWORD"]
+  description           = "SMTP credentials"
+  name                  = "smtp-credentials"
+}
+```
+
+This module does not support rotation, but it otherwise supports the same
+variables for permissions as the [generic secret module].
+
+[AWS Secrets Manager]: https://docs.aws.amazon.com/secretsmanager/latest/userguide/intro.html
+[KMS]: https://docs.aws.amazon.com/kms/latest/developerguide/overview.html
+[generic secret module]: ../secret
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_secret"></a> [secret](#module\_secret) | ../secret | n/a |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_admin_principals"></a> [admin\_principals](#input\_admin\_principals) | Principals allowed to peform admin actions (default: current account) | `list(string)` | `null` | no |
+| <a name="input_description"></a> [description](#input\_description) | Description for this secret | `string` | `null` | no |
+| <a name="input_environment_variables"></a> [environment\_variables](#input\_environment\_variables) | Environment variables for which a user must provide values | `list(string)` | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | Name for this secret | `string` | n/a | yes |
+| <a name="input_read_principals"></a> [read\_principals](#input\_read\_principals) | Principals allowed to read the secret (default: current account) | `list(string)` | `null` | no |
+| <a name="input_readwrite_principals"></a> [readwrite\_principals](#input\_readwrite\_principals) | Principals allowed to both read and write secrets | `list(string)` | `[]` | no |
+| <a name="input_resource_tags"></a> [resource\_tags](#input\_resource\_tags) | Tags to be applied to created resources | `map(string)` | `{}` | no |
+| <a name="input_secret_policies"></a> [secret\_policies](#input\_secret\_policies) | Overrides for the secret resource policies | `list(string)` | `[]` | no |
+| <a name="input_trust_tags"></a> [trust\_tags](#input\_trust\_tags) | Tags required on principals accessing the secret | `map(string)` | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_arn"></a> [arn](#output\_arn) | ARN of the created secret |
+| <a name="output_id"></a> [id](#output\_id) | Id of the created secret |
+| <a name="output_kms_key_alias"></a> [kms\_key\_alias](#output\_kms\_key\_alias) | Alias of the KMS key encrypting the secret |
+| <a name="output_kms_key_arn"></a> [kms\_key\_arn](#output\_kms\_key\_arn) | Alias of the KMS key encrypting the secret |
+| <a name="output_name"></a> [name](#output\_name) | Name of the created secret |
+| <a name="output_policy_json"></a> [policy\_json](#output\_policy\_json) | Policy json for consuming this secret |
+| <a name="output_secret_name"></a> [secret\_name](#output\_secret\_name) | Name of the created secret |
+<!-- END_TF_DOCS -->

--- a/user-managed-secret/README.md
+++ b/user-managed-secret/README.md
@@ -56,6 +56,7 @@ variables for permissions as the [generic secret module].
 | Name | Description |
 |------|-------------|
 | <a name="output_arn"></a> [arn](#output\_arn) | ARN of the created secret |
+| <a name="output_environment_variables"></a> [environment\_variables](#output\_environment\_variables) | Environment variables provided by this secret |
 | <a name="output_id"></a> [id](#output\_id) | Id of the created secret |
 | <a name="output_kms_key_alias"></a> [kms\_key\_alias](#output\_kms\_key\_alias) | Alias of the KMS key encrypting the secret |
 | <a name="output_kms_key_arn"></a> [kms\_key\_arn](#output\_kms\_key\_arn) | Alias of the KMS key encrypting the secret |

--- a/user-managed-secret/main.tf
+++ b/user-managed-secret/main.tf
@@ -1,0 +1,22 @@
+module "secret" {
+  source = "../secret"
+
+  admin_principals       = var.admin_principals
+  create_rotation_role   = false
+  create_rotation_policy = false
+  initial_value          = jsonencode(local.initial_value)
+  description            = var.description
+  name                   = var.name
+  read_principals        = var.read_principals
+  readwrite_principals   = var.readwrite_principals
+  resource_tags          = var.resource_tags
+  secret_policies        = var.secret_policies
+  trust_tags             = var.trust_tags
+}
+
+locals {
+  initial_value = zipmap(
+    var.environment_variables,
+    [for key in var.environment_variables : ""]
+  )
+}

--- a/user-managed-secret/makefile
+++ b/user-managed-secret/makefile
@@ -1,0 +1,59 @@
+TFLINTRC    := ../.tflint.hcl
+TFDOCSRC    ?= ../.terraform-docs.yml
+MODULEFILES := $(wildcard *.tf)
+
+.PHONY: default
+default: checkfmt validate docs lint
+
+.PHONY: checkfmt
+checkfmt: .fmt
+
+.PHONY: fmt
+fmt: $(MODULEFILES)
+	terraform fmt
+	@touch .fmt
+
+.PHONY: validate
+validate: .validate
+
+.PHONY: docs
+docs: README.md
+
+.PHONY: lint
+lint: .lint
+
+.lint: $(MODULEFILES) .lintinit
+	tflint --config=$(TFLINTRC)
+	@touch .lint
+
+.lintinit: $(TFLINTRC)
+	tflint --init --config=$(TFLINTRC)
+	@touch .lintinit
+
+README.md: $(MODULEFILES)
+	terraform-docs --config "$(TFDOCSRC)" markdown table . --output-file README.md
+
+.fmt: $(MODULEFILES)
+	terraform fmt -check
+	@touch .fmt
+
+.PHONY: init
+init: .init
+
+.init: versions.tf
+	terraform init -backend=false
+	@touch .init
+
+.validate: .init $(MODULEFILES) $(wildcard *.tf.example)
+	echo | cat - $(wildcard *.tf.example) > test.tf
+	if AWS_DEFAULT_REGION=us-east-1 terraform validate; then \
+		rm test.tf; \
+		touch .validate; \
+	else \
+		rm test.tf; \
+		false; \
+	fi
+
+.PHONY: clean
+clean:
+	rm -rf .fmt .init .lint .lintinit .terraform .terraform.lock.hcl .validate

--- a/user-managed-secret/outputs.tf
+++ b/user-managed-secret/outputs.tf
@@ -1,0 +1,39 @@
+output "arn" {
+  description = "ARN of the created secret"
+  value       = module.secret.arn
+}
+
+output "environment_variables" {
+  description = "Environment variables provided by this secret"
+  value       = module.secret.environment_variables
+}
+
+output "id" {
+  description = "Id of the created secret"
+  value       = module.secret.id
+}
+
+output "kms_key_alias" {
+  description = "Alias of the KMS key encrypting the secret"
+  value       = module.secret.kms_key_alias
+}
+
+output "kms_key_arn" {
+  description = "Alias of the KMS key encrypting the secret"
+  value       = module.secret.kms_key_arn
+}
+
+output "name" {
+  description = "Name of the created secret"
+  value       = module.secret.name
+}
+
+output "policy_json" {
+  description = "Policy json for consuming this secret"
+  value       = module.secret.policy_json
+}
+
+output "secret_name" {
+  description = "Name of the created secret"
+  value       = module.secret.secret_name
+}

--- a/user-managed-secret/variables.tf
+++ b/user-managed-secret/variables.tf
@@ -4,27 +4,15 @@ variable "admin_principals" {
   default     = null
 }
 
-variable "create_rotation_policy" {
-  description = "Set to false to disable creation of an IAM policy for rotation"
-  type        = bool
-  default     = true
-}
-
-variable "create_rotation_role" {
-  description = "Set to false to use an existing IAM role for rotation"
-  type        = bool
-  default     = true
-}
-
-variable "initial_value" {
-  description = "Initial value for this secret"
-  type        = string
-}
-
 variable "description" {
   description = "Description for this secret"
   type        = string
   default     = null
+}
+
+variable "environment_variables" {
+  description = "Environment variables for which a user must provide values"
+  type        = list(string)
 }
 
 variable "name" {
@@ -48,18 +36,6 @@ variable "resource_tags" {
   description = "Tags to be applied to created resources"
   type        = map(string)
   default     = {}
-}
-
-variable "rotation_role_name" {
-  description = "Override the name for the rotation role"
-  type        = string
-  default     = null
-}
-
-variable "rotation_trust_policies" {
-  description = "Overrides for the rotation role trust policies"
-  type        = list(string)
-  default     = []
 }
 
 variable "secret_policies" {

--- a/user-managed-secret/versions.tf
+++ b/user-managed-secret/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.14.0"
+}


### PR DESCRIPTION
On most applications we have at least one secret that must be set manually by a developer. This adds a module to directly support this use case.

It better supports these secrets by disabling the rotation policy and role (since rotation will not be enabled) and making it easier to provide the default blank value using environment variable format.
