### PR TITLE
Environment variable names aren't sensitive

### DIFF
--- a/secret/README.md
+++ b/secret/README.md
@@ -53,7 +53,7 @@ using the [secret rotation function module].
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.15.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
 
 ## Providers

--- a/secret/main.tf
+++ b/secret/main.tf
@@ -287,8 +287,8 @@ locals {
   admin_principals   = coalesce(var.admin_principals, [local.account_arn])
   rotation_role_name = coalesce(var.rotation_role_name, "${var.name}-rotation")
 
-  env_vars = [
+  env_vars = nonsensitive([
     for key in try(keys(jsondecode(var.initial_value)), []) :
     key if upper(key) == key
-  ]
+  ])
 }

--- a/secret/versions.tf
+++ b/secret/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.14.0"
+  required_version = ">= 0.15.0"
 
   required_providers {
     aws = {


### PR DESCRIPTION
Even if sensitive values go into the secret's initial value, the names of the environment variables for those values aren't secret.

This makes it possible to plug the `ENVIRONMENT_VARIABLES` value into a module
for a SecretProviderClass.
