### PR TITLE
Fix user managed secret environment variables

### DIFF
--- a/secret/main.tf
+++ b/secret/main.tf
@@ -288,7 +288,7 @@ locals {
   rotation_role_name = coalesce(var.rotation_role_name, "${var.name}-rotation")
 
   env_vars = nonsensitive([
-    for key in try(keys(jsondecode(var.initial_value)), []) :
+    for key in try(keys(jsondecode(sensitive(var.initial_value))), []) :
     key if upper(key) == key
   ])
 }

--- a/user-managed-secret/outputs.tf
+++ b/user-managed-secret/outputs.tf
@@ -5,7 +5,7 @@ output "arn" {
 
 output "environment_variables" {
   description = "Environment variables provided by this secret"
-  value       = module.secret.environment_variables
+  value       = var.environment_variables
 }
 
 output "id" {


### PR DESCRIPTION
- Terraform was complaining about calling `nonsensitive` when the value wasn't sensitive; this forces the initial value to potentially be sensitive to avoid the error.
- We can skip parsing out the environment variables for the user managed secret module, because they are passed in directly.
