### PR TITLE
Update to v5.x of terraform-provider-aws

### DIFF
--- a/customer-managed-kms/versions.tf
+++ b/customer-managed-kms/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/read-secret-policy/README.md
+++ b/read-secret-policy/README.md
@@ -31,13 +31,13 @@ module "secret_read_policy" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.15.5 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.0 |
 
 ## Resources
 

--- a/read-secret-policy/versions.tf
+++ b/read-secret-policy/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/secret-rotation-function/versions.tf
+++ b/secret-rotation-function/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/secret/README.md
+++ b/secret/README.md
@@ -54,13 +54,13 @@ using the [secret rotation function module].
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.15.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.0 |
 
 ## Resources
 

--- a/secret/main.tf
+++ b/secret/main.tf
@@ -40,7 +40,7 @@ data "aws_iam_policy_document" "secret" {
       ]
       principals {
         type        = "AWS"
-        identifiers = [statement.arn]
+        identifiers = [statement.value.arn]
       }
     }
   }
@@ -136,7 +136,7 @@ data "aws_iam_policy_document" "key" {
       resources = ["*"]
       principals {
         type        = "AWS"
-        identifiers = [statement.arn]
+        identifiers = [statement.value.arn]
       }
     }
   }
@@ -288,7 +288,7 @@ locals {
   rotation_role_name = coalesce(var.rotation_role_name, "${var.name}-rotation")
 
   env_vars = nonsensitive([
-    for key in try(keys(jsondecode(var.initial_value)), []) :
+    for key in try(keys(jsondecode(sensitive(var.initial_value))), []) :
     key if upper(key) == key
   ])
 }

--- a/secret/versions.tf
+++ b/secret/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/user-managed-secret/outputs.tf
+++ b/user-managed-secret/outputs.tf
@@ -5,7 +5,7 @@ output "arn" {
 
 output "environment_variables" {
   description = "Environment variables provided by this secret"
-  value       = module.secret.environment_variables
+  value       = var.environment_variables
 }
 
 output "id" {


### PR DESCRIPTION
Switch this and dependent modules to the v5.x of the Terraform AWS
provider to support the latest AWS features, like RDS' io2.

- Fix dynamic statement block

```
│   on .terraform/modules/production.auth_token/secret/main.tf line 43, in data "aws_iam_policy_document" "secret":
│   43:         identifiers = [statement.arn]
│
│ This object does not have an attribute named "arn".
```

https://developer.hashicorp.com/terraform/language/expressions/dynamic-blocks

- Fix user managed secret environment variables

NOTE: This cherry picks a commit from a [PR @jferris opened] to address the same issue.

  - Terraform was complaining about calling `nonsensitive` when the value
    wasn't sensitive; this forces the initial value to potentially be
    sensitive to avoid the error.
  - We can skip parsing out the environment variables for the user managed
    secret module, because they are passed in directly.

[PR @jferris opened]: https://github.com/thoughtbot/terraform-aws-secrets/pull/13