### PR TITLE
Upgrade AWS provider to 6.x in secret module

### DIFF
--- a/secret/main.tf
+++ b/secret/main.tf
@@ -281,7 +281,7 @@ data "aws_caller_identity" "this" {}
 locals {
   account_arn        = "arn:aws:iam::${local.account_id}:root"
   account_id         = data.aws_caller_identity.this.account_id
-  region             = data.aws_region.this.name
+  region             = data.aws_region.this.region
   sid_suffix         = join("", regexall("[[:alnum:]]+", var.name))
   read_principals    = coalesce(var.read_principals, [local.account_arn])
   admin_principals   = coalesce(var.admin_principals, [local.account_arn])

--- a/secret/versions.tf
+++ b/secret/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.0"
     }
   }
 }


### PR DESCRIPTION
Upgrading our internal terraform to use the latest AWS provider, so also have to update dependencies.

We have a module that uses the secrets module, so updating this first. I'd be happy to update the rest as well in a follow-up PR, if you'd like.